### PR TITLE
Prevent graphs from flattening to zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 0.5.1
+PROJECT_VERSION           := 0.5.2
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := helium-analysis
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ where appropriate) while the lines show the trailing average.
 Here is a graph showing more data points, including some invalid PoC witnesses.
 ![](https://user-images.githubusercontent.com/1075352/112706128-6ad03780-8e5f-11eb-943a-33b8ed942ecb.png)
 
-Looks like clever-oily-nightingale is no longer able to witnesses fantastic-fieery-scallop.
-![](https://user-images.githubusercontent.com/1075352/112706121-673cb080-8e5f-11eb-9ff0-2d46e0ce26c3.png)
+Something clearly changed and better signal strength!
+![](https://user-images.githubusercontent.com/1075352/112737511-4edc9c80-8f18-11eb-9327-96f420610b27.png)
 
 ## Invalid?
 

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -122,6 +122,10 @@ func generatePeerGraph(address, witness string, results []WitnessResult, min int
 	for _, ret := range results {
 		x := float64(ret.Timestamp)
 		y := float64(ret.Signal)
+		if y < Y_MIN || y > Y_MAX {
+			log.Warnf("Threw out invalid value outside of range %.02f to %.02f: %.02f", Y_MIN, Y_MAX, y)
+			continue
+		}
 		if ret.Type == RX {
 			rx_x = append(rx_x, x)
 			rx_vals = append(rx_vals, y)


### PR DESCRIPTION
If there were values out of the Y range, then the whole graph
got flattened.  So now we just throw them out since they're
invalid anyways right?

- Add better graph to README
- Bump version to v0.5.2