### PR TITLE
Auto-unlock Y Axis

### DIFF
--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -77,7 +77,6 @@ var HOTSPOT_CACHE map[string]Hotspot = map[string]Hotspot{}
 func getHotspot(address string) (Hotspot, error) {
 	v, ok := HOTSPOT_CACHE[address]
 	if ok {
-		log.Debugf("cache hit:  %s => %s", address, v.Name)
 		return v, nil
 	} else {
 		log.Debugf("cache miss: %s", address)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,10 @@ func main() {
 		os.Exit(0)
 	}
 
+	if min < 2 {
+		log.Fatalf("Please specify a --min value >= 2")
+	}
+
 	if hotspots {
 		err := downloadHotspots(HOTSPOT_CACHE_FILE)
 		if err != nil {


### PR DESCRIPTION
If we need to graph something outside of our range, we now
unlock the Y axis so the graph isn't flattened.

Require users to specify min >= 2 to prevent deadlock.