### PR TITLE
Determine timestamps better & fix cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 0.5.3
+PROJECT_VERSION           := 0.5.4
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := helium-analysis
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -293,13 +293,18 @@ func generatePeerGraphs(address string, challenges []Challenges, min int, zoom b
 	x_min := 0.0
 	x_max := 0.0
 	if !zoom {
-		c := *challenges[0].Path
-		p := *c[0].Witnesses
-		x_max = float64(p[0].Timestamp)
-		last := len(challenges) - 1
-		c = *challenges[last].Path
-		p = *c[0].Witnesses
-		x_min = float64(p[0].Timestamp)
+		for i := 0; x_max == 0; i++ {
+			max, err := challenges[i].GetTimestamp()
+			if err == nil {
+				x_max = float64(max)
+			}
+		}
+		for i := len(challenges) - 1; x_min == 0; i-- {
+			min, err := challenges[i].GetTimestamp()
+			if err == nil {
+				x_min = float64(min)
+			}
+		}
 	}
 
 	cnt := 0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,7 +116,7 @@ func main() {
 			log.Fatalf("%s", err)
 		}
 	} else {
-		c, err = readChallenges(CHALLENGES_CACHE_FILE, address, challengesExpires*3600, challengesCnt)
+		c, err = loadChallenges(CHALLENGES_CACHE_FILE, address, challengesExpires*3600, challengesCnt)
 		if err != nil {
 			log.WithError(err).Warnf("Unable to load challenges file. Refreshing...")
 			c, err = fetchChallenges(address, challengesCnt)


### PR DESCRIPTION
- Fix challenges.json cache invalidation when using
    different hotspot
- Fix some bugs (null pointer) when trying to get a
    timestamp for a set of Challenges
- Determine timestamps far more consistently
- Bump to v0.5.4