### PR TITLE
Add --force-cache and SNR to the graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Helium Analysis Changelog
 
+## Unreleased
+
+- Remove --hotspots flag
+- Add --force-cache flag to always use cache
+- Add SNR data to the graph
+
 ## v0.6.1 - 2021-03-29 
 
 - Fix graphing of invalid PoC.  Now we use the `is_valid` flag provided

--- a/cmd/challenges.go
+++ b/cmd/challenges.go
@@ -298,6 +298,7 @@ func getWitnessResults(address, witness string, challenges []Challenges) ([]Witn
 					Signal:         wit.Signal,
 					Type:           rxtx,
 					Valid:          wit.IsValid,
+					Snr:            wit.Snr,
 					ValidThreshold: minRssiPerSnr(wit.Snr),
 					Km:             km,
 					Mi:             mi,
@@ -375,7 +376,7 @@ func writeChallenges(challenges []Challenges, filename, address string, start ti
 }
 
 // read the cache file
-func loadChallenges(filename, address string, expires int64, start time.Time) ([]Challenges, error) {
+func loadChallenges(filename, address string, expires int64, start time.Time, forceCache bool) ([]Challenges, error) {
 	cache := ChallengeCache{}
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -386,7 +387,7 @@ func loadChallenges(filename, address string, expires int64, start time.Time) ([
 	if err != nil {
 		return []Challenges{}, err
 	}
-	if cache.CacheTime+expires < time.Now().Unix() {
+	if !forceCache && cache.CacheTime+expires < time.Now().Unix() {
 		return []Challenges{}, fmt.Errorf("Challenge cache is old.")
 	}
 	recordTime := time.Unix(cache.StartDate, 0)

--- a/cmd/hotspots.go
+++ b/cmd/hotspots.go
@@ -115,7 +115,7 @@ func getHotspotAddress(name string) (string, error) {
 }
 
 // Loads our hotspots from the cachefile
-func loadHotspots(filename string) error {
+func loadHotspots(filename string, forceCache bool) error {
 	file, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func loadHotspots(filename string) error {
 	}
 
 	age := time.Now().Unix() - cache.Time
-	if age > HOTSPOT_CACHE_TIMEOUT {
+	if !forceCache && age > HOTSPOT_CACHE_TIMEOUT {
 		log.Warnf("Hotspot cache is %dhrs old.  You may want to refresh via --hotspots",
 			age/60/60)
 	}


### PR DESCRIPTION
- When api.helium.io goes down, it's useful to just use the cache files
    even if they are out of date
- Add the SNR data to the graph.
- Remove --hotspots flag since it is automatically downloaded now

Refs: #21