### PR TITLE
Change how JSON files are for beacons/witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helium Analysis Changelog
 
+## Unreleased
+
+- Always generate JSON files for beacons & witnesses
+- Becaon & Witness JSON files now are limited to the data being graphed
+
 ## v0.9.0 - 2021-04-08
 
 - Complete CLI revamp


### PR DESCRIPTION
- Always generate the JSON files for the total hotspot
    beacons and witnesses even if graph is suppressed
- Becons & Witness JSON files now only contain the data
    represented in the graph